### PR TITLE
Fix typo in index.yaml

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -8,7 +8,7 @@ links:
   - title: Quickstart
     description: Quickly set up and run Telescope locally using Docker with a preconfigured SQLite database and config template.
     href: setup/quickstart.md
-  - title: Quering data
+  - title: Querying data
     description: Securely and effortlessly access your data through Telescope’s FlyQL-based interface - offering a consistent experience (currently with ClickHouse) without the complexity of raw SQL or varied API queries.
     href: concepts/querying.md
   - title: Auth


### PR DESCRIPTION
Fix a typo in one of the titles.