### PR TITLE
Added authentication using keycloak

### DIFF
--- a/backend/base/urls.py
+++ b/backend/base/urls.py
@@ -1,11 +1,13 @@
 from django.urls import include, path
 
 from allauth.socialaccount.providers.github.urls import urlpatterns as github_patterns
+from allauth.socialaccount.providers.openid_connect.urls import urlpatterns as openid_patterns
 from django.views.generic import RedirectView
+from telescope.urls import urlpatterns as telescope_patterns
 
 
 urlpatterns = [
     path("editor.worker.js", RedirectView.as_view(url="/static/editor.worker.js")),
     path("login/", include(github_patterns)),
-    path("", include("telescope.urls")),
+    path("", include(openid_patterns + telescope_patterns)),
 ]

--- a/backend/telescope/apps.py
+++ b/backend/telescope/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
 
 
 class TelescopeConfig(AppConfig):
@@ -7,3 +8,14 @@ class TelescopeConfig(AppConfig):
 
     def ready(self):
         import telescope.signals
+        post_migrate.connect(self._ensure_site_exists, sender=self)
+
+    def _ensure_site_exists(self, **kwargs):
+        from django.contrib.sites.models import Site
+        from django.conf import settings
+
+        site_id = settings.SITE_ID
+        Site.objects.update_or_create(
+            id=site_id,
+            defaults={"domain": settings.SITE_DOMAIN, "name": settings.SITE_NAME},
+        )

--- a/backend/telescope/config.py
+++ b/backend/telescope/config.py
@@ -145,7 +145,7 @@ def merge_dicts(first, second):
 def get_default_config():
     return {
         "gunicorn": {
-            "bind": "127.0.0.1:9898",
+            "bind": "0.0.0.0:9898",
             "workers": 8,
             "timeout": 120,
             "max_requests": 50,
@@ -162,6 +162,8 @@ def get_default_config():
                     "NAME": "telescope-default-db.sqlite3",
                 },
             },
+            "SITE_DOMAIN": "127.0.0.1:9898",
+            "SITE_NAME": "Default",
         },
         "limits": {
             "max_saved_views_per_user": 0,
@@ -172,6 +174,14 @@ def get_default_config():
                     "enabled": False,
                     "key": "",
                     "organizations": [],
+                    "default_group": None,
+                },
+                "keycloak": {
+                    "enabled": False,
+                    "server_url": "",
+                    "realm": "",
+                    "client_id": "",
+                    "client_secret": None,
                     "default_group": None,
                 },
             },

--- a/backend/telescope/signals.py
+++ b/backend/telescope/signals.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.dispatch import receiver
 from django.core.exceptions import PermissionDenied
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import Group
 
 from allauth.account.signals import user_logged_in
 from allauth.socialaccount.signals import pre_social_login
@@ -47,5 +47,18 @@ def add_github_user_to_default_group(request, user, **kwargs):
         return
 
     if user.socialaccount_set.filter(provider="github").exists():
+        default_group, created = Group.objects.get_or_create(name=default_group_name)
+        user.groups.add(default_group)
+
+
+@receiver([user_logged_in])
+def add_keycloak_user_to_default_group(request, user, **kwargs):
+    default_group_name = settings.CONFIG["auth"]["providers"]["keycloak"].get(
+        "default_group"
+    )
+    if not default_group_name:
+        return
+
+    if user.socialaccount_set.filter(provider="keycloak").exists():
         default_group, created = Group.objects.get_or_create(name=default_group_name)
         user.groups.add(default_group)

--- a/backend/telescope/templates/forms/login.html
+++ b/backend/telescope/templates/forms/login.html
@@ -27,11 +27,19 @@
         </div>
         <input class="btn-submit"  type="submit" value="Submit">
       </form>
-      {% if github_enabled %}
+      {% if github_enabled or keycloak_enabled %}
       <div style="display: flex; justify-content: center; align-items:center; margin-top: 10px;">or sign in with</div>
+      {% endif %}
+      {% if github_enabled %}
       <form action="/login/github/login/" method="post">
         {% csrf_token %}
         <input id="github_submit" class="btn-thirdparty" type="submit" value="GitHub">
+      </form>
+      {% endif %}
+      {% if keycloak_enabled %}
+      <form action="/oidc/keycloak/login/" method="post">
+        {% csrf_token %}
+        <input id="keycloak_submit" class="btn-thirdparty" type="submit" value="Keycloak">
       </form>
       {% endif %}
     </div>

--- a/backend/telescope/templates/forms/logout.html
+++ b/backend/telescope/templates/forms/logout.html
@@ -12,7 +12,7 @@
       <div class="form-label">Sign out. Are you sure?</div>
       <form action="/logout" method="post">
         {% csrf_token %}
-        <input class="btn-submit"  type="submit" value="Continue">
+        <input class="btn-submit" type="submit" value="Continue">
       </form>
     </div>
   </div>

--- a/backend/telescope/views/auth/views.py
+++ b/backend/telescope/views/auth/views.py
@@ -4,9 +4,9 @@ from django.db import transaction
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 from django.shortcuts import render, redirect
-from django.http import JsonResponse
 from django.views import View
 from django.conf import settings
+from urllib.parse import urlencode
 
 from allauth.socialaccount.models import SocialAccount
 from rest_framework.response import Response
@@ -24,12 +24,44 @@ from telescope.auth.forms import LoginForm, SuperuserForm
 from telescope.rbac.helpers import get_user_global_permissions
 
 
+def get_keycloak_logout_url(request):
+    keycloak_config = settings.CONFIG["auth"]["providers"]["keycloak"]
+
+    if not keycloak_config.get("enabled", False):
+        return None
+
+    server_url = keycloak_config["server_url"]
+    realm = keycloak_config["realm"]
+    client_id = keycloak_config["client_id"]
+
+    logout_base_url = f"{server_url}/realms/{realm}/protocol/openid-connect/logout"
+
+    params = {
+        "client_id": client_id,
+        "post_logout_redirect_uri": request.build_absolute_uri("/")
+    }
+
+    return f"{logout_base_url}?{urlencode(params)}"
+
+
+def should_logout_from_keycloak(user_id):
+    if not settings.CONFIG["auth"]["providers"]["keycloak"]["enabled"]:
+        return False
+
+    social_account = SocialAccount.objects.filter(
+        user_id=user_id,
+        provider='keycloak'
+    ).exists()
+    return social_account
+
+
 class LoginView(views.LoginView):
     template_name = "forms/login.html"
     form_class = LoginForm
     next_page = "/"
     extra_context = {
         "github_enabled": settings.CONFIG["auth"]["providers"]["github"]["enabled"],
+        "keycloak_enabled": settings.CONFIG["auth"]["providers"]["keycloak"]["enabled"],
         "force_github_auth": settings.CONFIG["auth"]["force_github_auth"],
     }
 
@@ -38,6 +70,7 @@ class LoginView(views.LoginView):
             return redirect("/")
         if User.objects.filter(is_superuser=True).count() == 0:
             return redirect("/setup")
+
         return super().dispatch(request, *args, **kwargs)
 
 
@@ -47,10 +80,18 @@ class LogoutView(View):
     def get(self, request):
         if settings.CONFIG["auth"]["enable_testing_auth"]:
             return redirect("/")
+
         return render(request, "forms/logout.html")
 
     def post(self, request):
+        user_id = request.user.id
         logout(request)
+
+        if should_logout_from_keycloak(user_id):
+            keycloak_logout_url = get_keycloak_logout_url(request)
+            if keycloak_logout_url:
+                return redirect(keycloak_logout_url)
+
         return redirect("/")
 
 
@@ -102,11 +143,17 @@ class WhoAmIView(APIView):
             "type": "local",
             "avatar_url": "",
         }
-        if social_account and social_account.provider == "github":
-            user_data = social_account.get_provider_account().get_user_data()
-            data["type"] = social_account.provider
-            data["username"] = user_data["login"]
-            data["avatar_url"] = user_data["avatar_url"]
+        if social_account:
+            if social_account.provider == "github":
+                user_data = social_account.get_provider_account().get_user_data()
+                data["type"] = social_account.provider
+                data["username"] = user_data["login"]
+                data["avatar_url"] = user_data["avatar_url"]
+            elif social_account.provider == "keycloak":
+                user_data = social_account.get_provider_account().get_user_data()
+                data["type"] = "keycloak"
+                data["username"] = user_data.get("preferred_username", user_data.get("name", request.user.username))
+                data["avatar_url"] = user_data.get("picture", "")
         serializer = WhoAmISerializer(data=data)
         if not serializer.is_valid():
             response.mark_failed(str(serializer.errors))

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -24,6 +24,8 @@ data:
         {{- range .Values.config.django.CSRF_TRUSTED_ORIGINS }}
         - {{ . | quote }}
         {{- end }}
+      SITE_DOMAIN: {{ .Values.config.django.SITE_DOMAIN | quote }}
+      SITE_NAME: {{ .Values.config.django.SITE_NAME | quote }}
       DATABASES:
         {{- if .Values.database.raw }}
         {{- toYaml .Values.database.raw | nindent 8 }}
@@ -59,6 +61,13 @@ data:
             - {{ . | quote }}
             {{- end }}
           default_group: {{ .Values.config.auth.providers.github.default_group }}
+        keycloak:
+          enabled: {{ .Values.config.auth.providers.keycloak.enabled }}
+          server_url: {{ .Values.config.auth.providers.keycloak.server_url | quote }}
+          realm: {{ .Values.config.auth.providers.keycloak.realm | quote }}
+          client_id: {{ .Values.config.auth.providers.keycloak.client_id | quote }}
+          client_secret: !env KEYCLOAK_CLIENT_SECRET
+          default_group: {{ .Values.config.auth.providers.keycloak.default_group }}
       force_github_auth: {{ .Values.config.auth.force_github_auth }}
       enable_testing_auth: {{ .Values.config.auth.enable_testing_auth }}
       testing_auth_username: {{ .Values.config.auth.testing_auth_username | quote }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -127,9 +127,15 @@
               "items": {
                 "type": "string"
               }
+            },
+            "SITE_DOMAIN": {
+              "type": "string"
+            },
+            "SITE_NAME": {
+              "type": "string"
             }
           },
-          "required": ["DEBUG", "ALLOWED_HOSTS", "CSRF_TRUSTED_ORIGINS"]
+          "required": ["DEBUG", "ALLOWED_HOSTS", "CSRF_TRUSTED_ORIGINS", "SITE_DOMAIN", "SITE_NAME"]
         },
         "auth": {
           "type": "object",
@@ -154,9 +160,33 @@
                     }
                   },
                   "required": ["enabled"]
+                },
+                "keycloak": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "server_url": {
+                      "type": "string"
+                    },
+                    "realm": {
+                      "type": "string"
+                    },
+                    "client_id": {
+                      "type": "string"
+                    },
+                    "client_secret": {
+                      "type": "string"
+                    },
+                    "default_group": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["enabled"]
                 }
               },
-              "required": ["github"]
+              "required": ["github", "keycloak"]
             }
           },
           "required": ["providers"]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,6 +41,8 @@ config:
       - "http://localhost:8080"
     DEBUG: false
     ALLOWED_HOSTS: ["*"]
+    SITE_DOMAIN: "127.0.0.1:8080"
+    SITE_NAME: "Default"
     # Database configuration is a separated section below
   limits:
     max_saved_views_per_user: 0
@@ -51,6 +53,13 @@ config:
         client_id: ""
         key: ""
         organizations: []
+        default_group: null
+      keycloak:
+        enabled: false
+        server_url: ""
+        realm: ""
+        client_id: ""
+        client_secret: ""
         default_group: null
     force_github_auth: false
     enable_testing_auth: false


### PR DESCRIPTION
Some comments on the solution

1) Had to connect django.site because without it allauth openid does not work. The only option is to refuse it, implement authentication yourself or use another library.
Accordingly, added Site generation to the signals and config variables
2) All permission management occurs inside the django application without any participation of keycloak
3) The session is controlled by django, because this is the current standard mechanism and there is no token exchange in the project. Added the ability to control the session lifetime to the config.
4) Did not implement force_keycloak_auth because access to local users may still be required, for example, the superuser, and with the force setting this cannot be done