### PR TITLE
Reduced image customization for deployment (#57)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
-FROM python:3.12-slim
+FROM node:20 AS frontend
+
+WORKDIR /opt/telescope/ui
+
+COPY ui/package*.json ./
+RUN npm ci
+
+COPY ui/ .
+RUN npm run build
+
+
+FROM python:3.12-slim AS backend
 
 WORKDIR /opt/telescope
 
@@ -12,5 +23,30 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY backend/ .
+
+COPY --from=frontend /opt/telescope/ui/dist/static ./telescope/static/
+COPY --from=frontend /opt/telescope/ui/dist/favicon.ico ./telescope/static/
+COPY --from=frontend /opt/telescope/ui/dist/editor.worker.js ./telescope/static/
+COPY --from=frontend /opt/telescope/ui/dist/editor.worker.js.map ./telescope/static/
+COPY --from=frontend /opt/telescope/ui/dist/json.worker.js ./telescope/static/
+COPY --from=frontend /opt/telescope/ui/dist/json.worker.js.map ./telescope/static/
+COPY --from=frontend /opt/telescope/ui/src/assets/namedlogo.png ./telescope/static/
+COPY --from=frontend /opt/telescope/ui/dist/index.html ./telescope/templates/
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+
+FROM python:3.12-slim AS base
+
+ENV DJANGO_COLLECTSTATIC=1
+
+WORKDIR /opt/telescope
+
+COPY --from=backend /usr/local /usr/local
+COPY --from=backend /opt/telescope /opt/telescope
+COPY --from=backend /entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["python", "app.py"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,3 +28,4 @@ typing_extensions==4.12.2
 tzlocal==5.2
 urllib3==2.5.0
 whitenoise==6.6.0
+psycopg2-binary==2.9.10

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+: "${DJANGO_SECRET_KEY:=dummysecret}"
+: "${DJANGO_COLLECTSTATIC:=1}"
+
+if [ "$DJANGO_COLLECTSTATIC" = "1" ]; then
+  python manage.py collectstatic --noinput
+fi
+
+exec "$@"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
           env:
             - name: TELESCOPE_CONFIG_FILE
               value: "/etc/telescope/config.yaml"
+            - name: DJANGO_COLLECTSTATIC
+              value: {{ .Values.djangoCollectstatic }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secretName }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -112,6 +112,7 @@ database:
 # Secret configuration
 # Telescope retrieves sensitive values from a Kubernetes secret as environment variables
 secretName: "telescope-secrets"  # Name of the secret containing required environment variables
+djangoCollectstatic: 1
 
 # Required secrets in the secret:
 # - DJANGO_SECRET_KEY: Always required for Django security


### PR DESCRIPTION
1)Changed the dockerfile so that one command would build the service completely, both the backend and the frontend
2)Added psycopg to the dependency so as not to install the dependency manually
3)Added static collection at container startup as a default behavior, with the ability to override this behavior using an environment variable DJANGO_COLLECTSTATIC

Perhaps these are big changes in user preparation. The goal was to reduce the amount of manual work for the user who will deploy the service in production.