### PR TITLE
 feat: add runtime BASE_URL support for deployment under custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Features planned for future implementation ([Telescope 1.0.0 milestone](https://
 - [Snapshot storage for long-term retention of log records, preventing data loss due to rotation](https://github.com/iamtelescope/telescope/issues/32).
 - [Live log trailing](https://github.com/iamtelescope/telescope/issues/31).
 - ~~Server-side modifiers (e.g., utilizing ClickHouse functions).~~ (I’ve decided that this feature is not required for stable release)
-- [Time zone support for the datetime selector](https://github.com/iamtelescope/telescope/issues/33).
 - [Helm chart](https://github.com/iamtelescope/telescope/issues/30).
 - ~~SAML and other authentication methods support.~~ (I’ve decided that this feature is not required for stable release)
 - [Audit log for any changes inside system](https://github.com/iamtelescope/telescope/issues/34).

--- a/backend/base/settings.py
+++ b/backend/base/settings.py
@@ -8,6 +8,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 CONFIG = get_config()
 
+# Base URL configuration for deployment under subpaths
+BASE_URL = CONFIG["frontend"].get("base_url", "").rstrip('/')
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
@@ -62,6 +65,10 @@ MIDDLEWARE.extend(
 CORS_ALLOW_ALL_ORIGINS = True
 CSRF_TRUSTED_ORIGINS = CONFIG["django"].get("CSRF_TRUSTED_ORIGINS", [])
 
+# Apply base URL configuration
+if BASE_URL:
+    FORCE_SCRIPT_NAME = BASE_URL
+
 ROOT_URLCONF = "base.urls"
 
 TEMPLATES = [
@@ -80,7 +87,7 @@ TEMPLATES = [
     },
 ]
 
-LOGIN_URL = "/login"
+LOGIN_URL = f"{BASE_URL}/login"
 
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
@@ -163,7 +170,7 @@ if CONFIG["auth"]["providers"]["github"]["enabled"]:
 
     SOCIALACCOUNT_PROVIDERS["github"] = github_config
 
-LOGIN_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL = f"{BASE_URL}/"
 
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "static"

--- a/backend/base/urls.py
+++ b/backend/base/urls.py
@@ -2,10 +2,10 @@ from django.urls import include, path
 
 from allauth.socialaccount.providers.github.urls import urlpatterns as github_patterns
 from django.views.generic import RedirectView
-
+from django.conf import settings
 
 urlpatterns = [
-    path("editor.worker.js", RedirectView.as_view(url="/static/editor.worker.js")),
+    path("editor.worker.js", RedirectView.as_view(url=f"{settings.BASE_URL}/static/editor.worker.js")),
     path("login/", include(github_patterns)),
     path("", include("telescope.urls")),
 ]

--- a/backend/telescope/config.py
+++ b/backend/telescope/config.py
@@ -80,6 +80,9 @@ SCHEMA = {
                 "show_docs_url": {
                     "type": "boolean",
                 },
+                "base_url": {
+                    "type": "string",
+                },
             },
         },
         "additionalProperties": True,
@@ -183,6 +186,7 @@ def get_default_config():
             "github_url": "https://github.com/iamtelescope/telescope",
             "docs_url": "https://iamtelescope.github.io/telescope/docs",
             "show_docs_url": True,
+            "base_url": "",
         },
         "logging": {
             "format": "default",

--- a/backend/telescope/templates/auth.html
+++ b/backend/telescope/templates/auth.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <base href="{% if base_url %}{{ base_url }}/{% else %}/{% endif %}">
     <title>Telescope</title>
+    <script>
+        const base = document.querySelector('base');
+        if (base && base.outerHTML.includes('{%')) {
+            base.setAttribute('href', '/');
+        }
+    </script>
   </head>
   <style>
   @import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');

--- a/backend/telescope/templates/forms/login.html
+++ b/backend/telescope/templates/forms/login.html
@@ -6,11 +6,11 @@
 <div style="height: 100vh; width: 100wh; background: linear-gradient(135deg, rgb(5, 7, 10), rgb(40, 60, 80));"{% if force_github_auth %} hidden{%endif%} >
   <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100vh;">
     <div style="max-width: 500px; width: 500px; min-width: 500px;display: flex; align-items: left;">
-      <img src="/static/namedlogo.png" style="margin-bottom: 10px; padding-left: 10px;" />
+      <img src="static/namedlogo.png" style="margin-bottom: 10px; padding-left: 10px;" />
     </div>
     <div class="form-box">
       <div class="form-label">Sign in to your account</div>
-      <form action="/login" method="post">
+      <form action="login" method="post">
         {% csrf_token %}
 
         {% for field in form %}
@@ -29,7 +29,7 @@
       </form>
       {% if github_enabled %}
       <div style="display: flex; justify-content: center; align-items:center; margin-top: 10px;">or sign in with</div>
-      <form action="/login/github/login/" method="post">
+      <form action="login/github/login/" method="post">
         {% csrf_token %}
         <input id="github_submit" class="btn-thirdparty" type="submit" value="GitHub">
       </form>

--- a/backend/telescope/templates/forms/logout.html
+++ b/backend/telescope/templates/forms/logout.html
@@ -6,11 +6,11 @@
 <div style="height: 100vh; width: 100wh; background: linear-gradient(135deg, rgb(5, 7, 10), rgb(40, 60, 80));">
   <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100vh;">
     <div style="max-width: 500px; width: 500px; min-width: 500px;display: flex; align-items: left;">
-      <img src="/static/namedlogo.png" style="margin-bottom: 10px; padding-left: 10px;" />
+      <img src="static/namedlogo.png" style="margin-bottom: 10px; padding-left: 10px;" />
     </div>
     <div class="form-box">
       <div class="form-label">Sign out. Are you sure?</div>
-      <form action="/logout" method="post">
+      <form action="logout" method="post">
         {% csrf_token %}
         <input class="btn-submit"  type="submit" value="Continue">
       </form>

--- a/backend/telescope/templates/forms/superuser.html
+++ b/backend/telescope/templates/forms/superuser.html
@@ -3,11 +3,11 @@
 <div style="height: 100vh; width: 100wh; background: linear-gradient(135deg, rgb(5, 7, 10), rgb(40, 60, 80));">
   <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100vh;">
     <div style="max-width: 500px; width: 500px; min-width: 500px;display: flex; align-items: left;">
-      <img src="/static/namedlogo.png" style="margin-bottom: 10px; padding-left: 10px;" />
+      <img src="static/namedlogo.png" style="margin-bottom: 10px; padding-left: 10px;" />
     </div>
     <div class="form-box">
       <div class="form-label">Create superuser account</div>
-      <form action="/setup" method="post">
+      <form action="setup" method="post">
         {% csrf_token %}
 
         {% for field in form %}

--- a/backend/telescope/views/auth/views.py
+++ b/backend/telescope/views/auth/views.py
@@ -29,8 +29,9 @@ rbac_manager = RBACManager()
 class LoginView(views.LoginView):
     template_name = "forms/login.html"
     form_class = LoginForm
-    next_page = "/"
+    next_page = settings.LOGIN_REDIRECT_URL
     extra_context = {
+        "base_url": settings.BASE_URL or "",
         "github_enabled": settings.CONFIG["auth"]["providers"]["github"]["enabled"],
         "force_github_auth": settings.CONFIG["auth"]["force_github_auth"],
     }
@@ -49,7 +50,9 @@ class LogoutView(View):
     def get(self, request):
         if settings.CONFIG["auth"]["enable_testing_auth"]:
             return redirect("/")
-        return render(request, "forms/logout.html")
+        return render(request, "forms/logout.html", {
+            "base_url": settings.BASE_URL or ""
+        })
 
     def post(self, request):
         logout(request)
@@ -66,7 +69,10 @@ class SuperuserView(View):
 
     def get(self, request):
         form = SuperuserForm
-        return render(request, "forms/superuser.html", {"form": form})
+        return render(request, "forms/superuser.html", {
+            "form": form,
+            "base_url": settings.BASE_URL or ""
+        })
 
     def post(self, request):
         form = SuperuserForm(request.POST)
@@ -83,7 +89,10 @@ class SuperuserView(View):
                 form.add_error(f"Unhandled exception: {err}")
             else:
                 return redirect("/login")
-        return render(request, "forms/superuser.html", {"form": form})
+        return render(request, "forms/superuser.html", {
+            "form": form,
+            "base_url": settings.BASE_URL or ""
+        })
 
 
 class WhoAmIView(APIView):

--- a/backend/telescope/views/index.py
+++ b/backend/telescope/views/index.py
@@ -11,7 +11,10 @@ from telescope.response import UIResponse
 
 @login_required
 def index(request):
-    return render(request, "index.html")
+    from django.conf import settings
+    return render(request, "index.html", {
+        "base_url": settings.BASE_URL or ""
+    })
 
 
 class ConfigView(APIView):

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -67,6 +67,7 @@ data:
       docs_url: {{ .Values.config.frontend.docs_url | quote }}
       show_docs_url: {{ .Values.config.frontend.show_docs_url }}
       show_github_url: {{ .Values.config.frontend.show_github_url }}
+      base_url: {{ .Values.config.frontend.base_url | quote }}
     logging:
       format: {{ .Values.config.logging.format | quote }}
       levels:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -60,6 +60,7 @@ config:
     docs_url: "https://docs.iamtelescope.net"
     show_docs_url: true
     show_github_url: false
+    base_url: ""
   logging:
     format: "default"
     levels:

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,11 +1,18 @@
 <!doctype html>
 <html lang="">
     <head>
+        <base href="{% if base_url %}{{ base_url }}/{% else %}/{% endif %}">
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-        <link rel="icon" href="/static/favicon.ico" />
+        <link rel="icon" href="./static/favicon.ico" />
         <title>Telescope</title>
+        <script>
+            const base = document.querySelector('base');
+            if (base && base.outerHTML.includes('{%')) {
+                base.setAttribute('href', '/');
+            }
+        </script>
     </head>
     <body>
         <noscript>

--- a/ui/src/composables/sources/useDeleteSource.js
+++ b/ui/src/composables/sources/useDeleteSource.js
@@ -1,4 +1,7 @@
 import { ref } from 'vue'
+import HTTP from '@/utils/http'
+
+const http = new HTTP()
 
 const useDeleteSource = (slug) => {
     const result = ref(null)
@@ -7,18 +10,13 @@ const useDeleteSource = (slug) => {
 
     const load = async () => {
         try {
-            let url = `/ui/v1/sources/${slug}`
-            let requestOptions = {
-                method: 'DELETE',
-                headers: {},
-            }
+            let url = `ui/v1/sources/${slug}`
+            let response = await http.Delete(url)
 
-            let response = await fetch(url, requestOptions)
-
-            if (!response.ok) {
-                throw Error(`failed to fetch ${response.url}. ${response.status}: ${response.statusText}`)
+            if (!response.result) {
+                throw Error(response.errors?.[0] || 'Failed to delete source')
             } else {
-                result.value = await response.json()
+                result.value = response.data
                 loading.value = false
             }
         } catch (err) {

--- a/ui/src/composables/sources/usePatchSource.js
+++ b/ui/src/composables/sources/usePatchSource.js
@@ -1,4 +1,7 @@
 import { ref } from 'vue'
+import HTTP from '@/utils/http'
+
+const http = new HTTP()
 
 const usePatchSource = () => {
     const result = ref(null)
@@ -7,19 +10,13 @@ const usePatchSource = () => {
 
     const load = async (slug, data) => {
         try {
-            let url = `/ui/v1/sources/${slug}`
-            let requestOptions = {
-                method: 'PATCH',
-                headers: {},
-                body: JSON.stringify(data),
-            }
+            let url = `ui/v1/sources/${slug}`
+            let response = await http.Patch(url, data)
 
-            let response = await fetch(url, requestOptions)
-
-            if (!response.ok) {
-                throw Error(`failed to fetch ${response.url}. ${response.status}: ${response.statusText}`)
+            if (!response.result) {
+                throw Error(response.errors?.[0] || 'Failed to patch source')
             } else {
-                result.value = await response.json()
+                result.value = response.data
                 loading.value = false
             }
         } catch (err) {

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -112,7 +112,7 @@ const routes = [
 ]
 
 const router = createRouter({
-    history: createWebHistory(process.env.BASE_URL),
+    history: createWebHistory(),
     routes,
 })
 
@@ -120,7 +120,7 @@ router.beforeEach(async (to, from) => {
     const { isLoggedIn } = storeToRefs(useAuthStore())
 
     if (!isLoggedIn.value && to.name !== 'login') {
-        window.location = '/login'
+        window.location = 'login'
     }
 })
 

--- a/ui/src/sdk/services/auth.js
+++ b/ui/src/sdk/services/auth.js
@@ -4,20 +4,20 @@ const http = new HTTP()
 
 class AuthService {
     getCurrentUser = async () => {
-        let response = await http.Get('/ui/v1/auth/whoami')
+        let response = await http.Get('ui/v1/auth/whoami')
         return response
     }
     getCurrentUserAPITokens = async () => {
-        let response = await http.Get('/ui/v1/auth/api_tokens')
+        let response = await http.Get('ui/v1/auth/api_tokens')
         return response
     }
     createAPIToken = async (data) => {
-        let response = await http.Post('/ui/v1/auth/api_tokens', data)
+        let response = await http.Post('ui/v1/auth/api_tokens', data)
         return response
     }
     deleteCurrentUserAPITokens = async (tokens) => {
         let data = { tokens: tokens }
-        let response = await http.Post('/ui/v1/auth/api_tokens/delete', data)
+        let response = await http.Post('ui/v1/auth/api_tokens/delete', data)
         return response
     }
 }

--- a/ui/src/sdk/services/group.js
+++ b/ui/src/sdk/services/group.js
@@ -5,48 +5,48 @@ const http = new HTTP()
 class GroupService {
     createGroup = async (groupName) => {
         let data = { name: groupName }
-        let response = await http.Post('/ui/v1/rbac/groups', data)
+        let response = await http.Post('ui/v1/rbac/groups', data)
         return response
     }
     deleteGroup = async (groupId) => {
-        let response = await http.Delete(`/ui/v1/rbac/groups/${groupId}`)
+        let response = await http.Delete(`ui/v1/rbac/groups/${groupId}`)
         return response
     }
     updateGroup = async (groupId, groupName) => {
         let data = { name: groupName }
-        let response = await http.Patch(`/ui/v1/rbac/groups/${groupId}`, data)
+        let response = await http.Patch(`ui/v1/rbac/groups/${groupId}`, data)
         return response
     }
     getGroup = async (groupId) => {
-        let response = await http.Get(`/ui/v1/rbac/groups/${groupId}`)
+        let response = await http.Get(`ui/v1/rbac/groups/${groupId}`)
         return response
     }
     getGroups = async () => {
-        let response = await http.Get('/ui/v1/rbac/groups')
+        let response = await http.Get('ui/v1/rbac/groups')
         return response
     }
     getSimpleGroups = async () => {
-        let response = await http.Get('/ui/v1/rbac/simplegroups')
+        let response = await http.Get('ui/v1/rbac/simplegroups')
         return response
     }
     addUsers = async (groupId, usersIds) => {
         let data = { ids: usersIds }
-        let response = await http.Post(`/ui/v1/rbac/groups/${groupId}/addUsers`, data)
+        let response = await http.Post(`ui/v1/rbac/groups/${groupId}/addUsers`, data)
         return response
     }
     removeUsers = async (groupId, usersIds) => {
         let data = { ids: usersIds }
-        let response = await http.Post(`/ui/v1/rbac/groups/${groupId}/removeUsers`, data)
+        let response = await http.Post(`ui/v1/rbac/groups/${groupId}/removeUsers`, data)
         return response
     }
     grantRole = async (groupId, roleName) => {
         let data = { role: roleName }
-        let response = await http.Post(`/ui/v1/rbac/groups/${groupId}/grantRole`, data)
+        let response = await http.Post(`ui/v1/rbac/groups/${groupId}/grantRole`, data)
         return response
     }
     revokeRole = async (groupId, roleName) => {
         let data = { role: roleName }
-        let response = await http.Post(`/ui/v1/rbac/groups/${groupId}/revokeRole`, data)
+        let response = await http.Post(`ui/v1/rbac/groups/${groupId}/revokeRole`, data)
         return response
     }
 }

--- a/ui/src/sdk/services/role.js
+++ b/ui/src/sdk/services/role.js
@@ -4,11 +4,11 @@ const http = new HTTP()
 
 class RoleService {
     getRole = async (roleType, roleName) => {
-        let response = await http.Get(`/ui/v1/rbac/roles/${roleType}/${roleName}`)
+        let response = await http.Get(`ui/v1/rbac/roles/${roleType}/${roleName}`)
         return response
     }
     getRoles = async () => {
-        let response = await http.Get('/ui/v1/rbac/roles')
+        let response = await http.Get('ui/v1/rbac/roles')
         return response
     }
 }

--- a/ui/src/sdk/services/source.js
+++ b/ui/src/sdk/services/source.js
@@ -4,31 +4,31 @@ const http = new HTTP()
 
 class SourceService {
     createSource = async (data) => {
-        let response = await http.Post('/ui/v1/sources', data)
+        let response = await http.Post('ui/v1/sources', data)
         return response
     }
     deleteSource = async (sourceSlug) => {
-        let response = await http.Delete(`/ui/v1/sources/${sourceSlug}`)
+        let response = await http.Delete(`ui/v1/sources/${sourceSlug}`)
         return response
     }
     updateSource = async (sourceSlug, data) => {
-        let response = await http.Patch(`/ui/v1/sources/${sourceSlug}`, data)
+        let response = await http.Patch(`ui/v1/sources/${sourceSlug}`, data)
         return response
     }
     getSource = async (sourceSlug) => {
-        let response = await http.Get(`/ui/v1/sources/${sourceSlug}`)
+        let response = await http.Get(`ui/v1/sources/${sourceSlug}`)
         return response
     }
     getSources = async () => {
-        let response = await http.Get('/ui/v1/sources')
+        let response = await http.Get('ui/v1/sources')
         return response
     }
     getSourceRoleBindings = async (sourceSlug) => {
-        let response = await http.Get(`/ui/v1/sources/${sourceSlug}/roleBindings`)
+        let response = await http.Get(`ui/v1/sources/${sourceSlug}/roleBindings`)
         return response
     }
     testConnection = async (kind, connectionData) => {
-        let response = await http.Post(`/ui/v1/services/testSourceConnection/${kind}`, connectionData)
+        let response = await http.Post(`ui/v1/services/testSourceConnection/${kind}`, connectionData)
         return response
     }
     getSourceSchema = async (kind, data) => {
@@ -49,7 +49,7 @@ class SourceService {
         if (group != null) {
             data['subject'] = { kind: 'group', name: group.name }
         }
-        let response = await http.Post(`/ui/v1/sources/${sourceSlug}/grantRole`, data)
+        let response = await http.Post(`ui/v1/sources/${sourceSlug}/grantRole`, data)
         return response
     }
     revokeSourceRole = async (sourceSlug, user, group, role) => {
@@ -66,39 +66,39 @@ class SourceService {
         if (group != null) {
             data['subject'] = { kind: 'group', name: group.name }
         }
-        let response = await http.Post(`/ui/v1/sources/${sourceSlug}/revokeRole`, data)
+        let response = await http.Post(`ui/v1/sources/${sourceSlug}/revokeRole`, data)
         return response
     }
     getData = async (sourceSlug, params, signal) => {
-        let response = await http.Post(`/ui/v1/sources/${sourceSlug}/data`, params, signal)
+        let response = await http.Post(`ui/v1/sources/${sourceSlug}/data`, params, signal)
         return response
     }
     getGraphData = async (sourceSlug, params, signal) => {
-        let response = await http.Post(`/ui/v1/sources/${sourceSlug}/graphData`, params, signal)
+        let response = await http.Post(`ui/v1/sources/${sourceSlug}/graphData`, params, signal)
         return response
     }
     autocomplete = async (sourceSlug, params) => {
-        let response = await http.Post(`/ui/v1/sources/${sourceSlug}/autocomplete`, params)
+        let response = await http.Post(`ui/v1/sources/${sourceSlug}/autocomplete`, params)
         return response
     }
     getContextFieldData = async (sourceSlug, params) => {
-        let response = await http.Post(`/ui/v1/sources/${sourceSlug}/contextFieldData`, params)
+        let response = await http.Post(`ui/v1/sources/${sourceSlug}/contextFieldData`, params)
         return response
     }
     getSavedView = async (sourceSlug, viewSlug) => {
-        return await http.Get(`/ui/v1/sources/${sourceSlug}/savedViews/${viewSlug}`)
+        return await http.Get(`ui/v1/sources/${sourceSlug}/savedViews/${viewSlug}`)
     }
     getSavedViews = async (sourceSlug) => {
-        return await http.Get(`/ui/v1/sources/${sourceSlug}/savedViews`)
+        return await http.Get(`ui/v1/sources/${sourceSlug}/savedViews`)
     }
     updateSavedView = async (sourceSlug, viewSlug, data) => {
-        return await http.Patch(`/ui/v1/sources/${sourceSlug}/savedViews/${viewSlug}`, data)
+        return await http.Patch(`ui/v1/sources/${sourceSlug}/savedViews/${viewSlug}`, data)
     }
     createSavedView = async (sourceSlug, data) => {
-        return await http.Post(`/ui/v1/sources/${sourceSlug}/savedViews`, data)
+        return await http.Post(`ui/v1/sources/${sourceSlug}/savedViews`, data)
     }
     deleteSavedView = async (sourceSlug, viewSlug) => {
-        return await http.Delete(`/ui/v1/sources/${sourceSlug}/savedViews/${viewSlug}`)
+        return await http.Delete(`ui/v1/sources/${sourceSlug}/savedViews/${viewSlug}`)
     }
 }
 

--- a/ui/src/sdk/services/user.js
+++ b/ui/src/sdk/services/user.js
@@ -4,11 +4,11 @@ const http = new HTTP()
 
 class UserService {
     getUsers = async () => {
-        let response = await http.Get('/ui/v1/rbac/users')
+        let response = await http.Get('ui/v1/rbac/users')
         return response
     }
     getSimpleUsers = async () => {
-        let response = await http.Get('/ui/v1/rbac/simpleusers')
+        let response = await http.Get('ui/v1/rbac/simpleusers')
         return response
     }
 }

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -14,7 +14,7 @@ export const useConfigStore = defineStore('config', () => {
     })
 
     async function load() {
-        let response = await http.Get('/ui/v1/config')
+        let response = await http.Get('ui/v1/config')
         config.value = response.data
     }
     return { config, load }

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -5,6 +5,7 @@ const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 module.exports = defineConfig({
     outputDir: 'dist',
     assetsDir: 'static',
+    publicPath: './',
     transpileDependencies: true,
     devServer: {
         client: false,


### PR DESCRIPTION
Summary
Implement dynamic base URL support allowing Telescope to be deployed under any path prefix (e.g., /telescope, /app, /monitoring) without requiring rebuilds.

Changes Made

Backend (Django)
- Extract `BASE_URL` from environment variable in `settings.py`
- Apply `FORCE_SCRIPT_NAME` to prefix all Django URLs
- Make `LOGIN_URL`, &`LOGIN_REDIRECT_URL` dynamic
- Update index view to pass `base_url` as template context
- Udated Django templates to handle base_url

Frontend (Vue.js)
- Add Django template `<base>` tag to `index.html` for auto-detection
- Refactor composables (`usePatchSource`, `useDeleteSource`) to use HTTP utility
- Simplify router to auto-detect base from `<base>` tag
- Changed number of absolute paths to relative paths.

Helm Templates updated

* Passing base_url to Django templates

* README.md update

* removed comments

* Added fall back script to catch base URl when going direct to ui server

* Replicating script to Auth template

# Why

<!--
Please describe why you are proposing this code change.
-->

# What

<!--
Please explain what you did. For small/trivial changes a single paragraph is
probably sufficient. For any larger changes this should include more context.
-->

# References

<!-- Please include links to other artifacts related to this code change if there are any. -->
