### PR TITLE
feat: support okta authentication provider

### DIFF
--- a/backend/base/settings.py
+++ b/backend/base/settings.py
@@ -9,7 +9,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 CONFIG = get_config()
 
 # Base URL configuration for deployment under subpaths
-BASE_URL = CONFIG["frontend"].get("base_url", "").rstrip('/')
+BASE_URL = CONFIG["frontend"].get("base_url", "").rstrip("/")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
@@ -41,6 +41,9 @@ INSTALLED_APPS = [
 
 if CONFIG["auth"]["providers"]["github"]["enabled"]:
     INSTALLED_APPS.append("allauth.socialaccount.providers.github")
+
+if CONFIG["auth"]["providers"]["okta"]["enabled"]:
+    INSTALLED_APPS.append("allauth.socialaccount.providers.okta")
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -169,6 +172,27 @@ if CONFIG["auth"]["providers"]["github"]["enabled"]:
         github_config["SCOPE"] = ["read:org"]
 
     SOCIALACCOUNT_PROVIDERS["github"] = github_config
+
+if CONFIG["auth"]["providers"]["okta"]["enabled"]:
+    okta_config = {
+        "APP": {
+            "client_id": CONFIG["auth"]["providers"]["okta"]["client_id"],
+            "secret": CONFIG["auth"]["providers"]["okta"]["secret"],
+        },
+        "OKTA_BASE_URL": CONFIG["auth"]["providers"]["okta"]["base_url"],
+        "SCOPE": CONFIG["auth"]["providers"]["okta"]
+        .get("scope", "openid profile email")
+        .split(),
+    }
+    if CONFIG["auth"]["providers"]["okta"].get("pkce_enabled", True):
+        okta_config["OAUTH_PKCE_ENABLED"] = True
+
+    SOCIALACCOUNT_PROVIDERS["okta"] = okta_config
+
+if CONFIG["django"].get("SECURE_PROXY_SSL_HEADER"):
+    header_config = CONFIG["django"]["SECURE_PROXY_SSL_HEADER"]
+    if isinstance(header_config, list) and len(header_config) == 2:
+        SECURE_PROXY_SSL_HEADER = tuple(header_config)
 
 LOGIN_REDIRECT_URL = f"{BASE_URL}/"
 

--- a/backend/base/urls.py
+++ b/backend/base/urls.py
@@ -1,11 +1,27 @@
 from django.urls import include, path
 
-from allauth.socialaccount.providers.github.urls import urlpatterns as github_patterns
 from django.views.generic import RedirectView
 from django.conf import settings
 
+oauth_patterns = []
+
+if settings.CONFIG["auth"]["providers"]["github"]["enabled"]:
+    from allauth.socialaccount.providers.github.urls import (
+        urlpatterns as github_patterns,
+    )
+
+    oauth_patterns.extend(github_patterns)
+
+if settings.CONFIG["auth"]["providers"]["okta"]["enabled"]:
+    from allauth.socialaccount.providers.okta.urls import urlpatterns as okta_patterns
+
+    oauth_patterns.extend(okta_patterns)
+
 urlpatterns = [
-    path("editor.worker.js", RedirectView.as_view(url=f"{settings.BASE_URL}/static/editor.worker.js")),
-    path("login/", include(github_patterns)),
+    path(
+        "editor.worker.js",
+        RedirectView.as_view(url=f"{settings.BASE_URL}/static/editor.worker.js"),
+    ),
+    path("login/", include(oauth_patterns)),
     path("", include("telescope.urls")),
 ]

--- a/backend/telescope/config.py
+++ b/backend/telescope/config.py
@@ -126,6 +126,23 @@ def validate(config, schema):
                 )
             )
 
+        if config["auth"]["force_auth_provider"]:
+            provider = config["auth"]["force_auth_provider"]
+            if provider not in ["github", "okta"]:
+                errors.append(
+                    (
+                        "auth.force_auth_provider",
+                        "must be either 'github' or 'okta'",
+                    )
+                )
+            elif not config["auth"]["providers"].get(provider, {}).get("enabled"):
+                errors.append(
+                    (
+                        "auth.force_auth_provider",
+                        f"cannot be '{provider}' if {provider} provider is not enabled",
+                    )
+                )
+
     if errors:
         raise ConfigValidationError(message="Malformed configuration", errors=errors)
 
@@ -177,8 +194,19 @@ def get_default_config():
                     "organizations": [],
                     "default_group": None,
                 },
+                "okta": {
+                    "enabled": False,
+                    "client_id": "",
+                    "secret": "",
+                    "base_url": "",
+                    "default_group": None,
+                    "scope": "openid profile email",
+                    "pkce_enabled": True,
+                },
             },
             "force_github_auth": False,
+            "force_auth_provider": None,
+            "local_login_secret_path": None,
             "enable_testing_auth": False,
             "testing_auth_username": "telescope",
         },

--- a/backend/telescope/rbac/manager.py
+++ b/backend/telescope/rbac/manager.py
@@ -166,7 +166,9 @@ class RBACManager:
 
         if pk is not None:
             if not objects:
-                raise model_class.DoesNotExist(f"object with pk {pk} does not exist or you have no permissions to read it")
+                raise model_class.DoesNotExist(
+                    f"object with pk {pk} does not exist or you have no permissions to read it"
+                )
             elif len(objects) > 1:
                 raise model_class.MultipleObjectsReturned(
                     f"returned more than one {model_class.__name__} -- it returned {len(objects)}!"
@@ -509,7 +511,12 @@ class RBACManager:
             view = SavedView.objects.get(
                 Q(slug=view_slug, source=source, user=user, scope=VIEW_SCOPE_PERSONAL)
                 | Q(slug=view_slug, source=source, scope=VIEW_SCOPE_SOURCE)
-                | Q(slug=view_slug, source=source, scope=VIEW_SCOPE_PERSONAL, shared=True)
+                | Q(
+                    slug=view_slug,
+                    source=source,
+                    scope=VIEW_SCOPE_PERSONAL,
+                    shared=True,
+                )
             )
         except SavedView.DoesNotExist:
             raise SavedView.DoesNotExist(

--- a/backend/telescope/serializers/source.py
+++ b/backend/telescope/serializers/source.py
@@ -156,8 +156,6 @@ class GetSourceSchemaDockerSerializer(serializers.Serializer):
     connection_id = serializers.IntegerField()
 
 
-
-
 class SourceFieldSerializer(serializers.Serializer):
     display_name = serializers.CharField(allow_blank=True)
     type = serializers.CharField()

--- a/backend/telescope/services/connection.py
+++ b/backend/telescope/services/connection.py
@@ -2,7 +2,10 @@ from typing import Optional, Tuple
 from django.contrib.auth.models import User, Group
 from django.db import transaction
 
-from telescope.services.exceptions import SerializerValidationError, ConnectionInUseError
+from telescope.services.exceptions import (
+    SerializerValidationError,
+    ConnectionInUseError,
+)
 from telescope.models import Connection, Source
 from telescope.rbac import permissions
 from telescope.rbac.roles import ConnectionRole
@@ -123,10 +126,7 @@ class ConnectionService:
             # Check if connection is being used by any sources
             source_count = Source.objects.filter(conn_id=pk).count()
             if source_count > 0:
-                raise ConnectionInUseError(
-                    connection_id=pk,
-                    source_count=source_count
-                )
+                raise ConnectionInUseError(connection_id=pk, source_count=source_count)
 
             Connection.objects.get(pk=pk).delete()
 

--- a/backend/telescope/services/exceptions.py
+++ b/backend/telescope/services/exceptions.py
@@ -5,6 +5,7 @@ class SerializerValidationError(Exception):
 
 class ConnectionInUseError(Exception):
     """Raised when attempting to delete a connection that is being used by sources"""
+
     def __init__(self, connection_id, source_count):
         self.connection_id = connection_id
         self.source_count = source_count

--- a/backend/telescope/templates/forms/login.html
+++ b/backend/telescope/templates/forms/login.html
@@ -3,7 +3,7 @@
 
 {% endblock %}
 {% block body %}
-<div style="height: 100vh; width: 100wh; background: linear-gradient(135deg, rgb(5, 7, 10), rgb(40, 60, 80));"{% if force_github_auth %} hidden{%endif%} >
+<div style="height: 100vh; width: 100wh; background: linear-gradient(135deg, rgb(5, 7, 10), rgb(40, 60, 80));"{% if force_github_auth or force_auth_provider %} hidden{%endif%} >
   <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100vh;">
     <div style="max-width: 500px; width: 500px; min-width: 500px;display: flex; align-items: left;">
       <img src="static/namedlogo.png" style="margin-bottom: 10px; padding-left: 10px;" />
@@ -27,11 +27,19 @@
         </div>
         <input class="btn-submit"  type="submit" value="Submit">
       </form>
-      {% if github_enabled %}
+      {% if github_enabled or okta_enabled %}
       <div style="display: flex; justify-content: center; align-items:center; margin-top: 10px;">or sign in with</div>
+      {% endif %}
+      {% if github_enabled %}
       <form action="login/github/login/" method="post">
         {% csrf_token %}
         <input id="github_submit" class="btn-thirdparty" type="submit" value="GitHub">
+      </form>
+      {% endif %}
+      {% if okta_enabled %}
+      <form action="login/okta/login/" method="post">
+        {% csrf_token %}
+        <input id="okta_submit" class="btn-thirdparty" type="submit" value="Okta">
       </form>
       {% endif %}
     </div>
@@ -40,6 +48,15 @@
 {% if force_github_auth %}
 <script>
 document.getElementById("github_submit").click()
+</script>
+{% endif %}
+{% if force_auth_provider == 'github' %}
+<script>
+document.getElementById("github_submit").click()
+</script>
+{% elif force_auth_provider == 'okta' %}
+<script>
+document.getElementById("okta_submit").click()
 </script>
 {% endif %}
 {% endblock %}

--- a/backend/telescope/urls.py
+++ b/backend/telescope/urls.py
@@ -14,6 +14,7 @@ import telescope.api.stub as stub_api
 
 urlpatterns = [
     path("login", auth.LoginView.as_view(), name="login"),
+    path("login/<str:secret_path>", auth.LocalLoginView.as_view(), name="local_login"),
     path("logout", auth.LogoutView.as_view(), name="logout"),
     path("setup", auth.SuperuserView.as_view(), name="setup"),
     path("api/v1/connections", connection_api.ConnectionView.as_view()),

--- a/backend/telescope/views/auth/views.py
+++ b/backend/telescope/views/auth/views.py
@@ -33,7 +33,9 @@ class LoginView(views.LoginView):
     extra_context = {
         "base_url": settings.BASE_URL or "",
         "github_enabled": settings.CONFIG["auth"]["providers"]["github"]["enabled"],
+        "okta_enabled": settings.CONFIG["auth"]["providers"]["okta"]["enabled"],
         "force_github_auth": settings.CONFIG["auth"]["force_github_auth"],
+        "force_auth_provider": settings.CONFIG["auth"]["force_auth_provider"],
     }
 
     def dispatch(self, request, *args, **kwargs):
@@ -44,15 +46,50 @@ class LoginView(views.LoginView):
         return super().dispatch(request, *args, **kwargs)
 
 
+class LocalLoginView(views.LoginView):
+    template_name = "forms/login.html"
+    form_class = LoginForm
+    next_page = settings.LOGIN_REDIRECT_URL
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "base_url": settings.BASE_URL or "",
+                "github_enabled": settings.CONFIG["auth"]["providers"]["github"][
+                    "enabled"
+                ],
+                "okta_enabled": settings.CONFIG["auth"]["providers"]["okta"]["enabled"],
+                "force_github_auth": False,
+                "force_auth_provider": None,
+            }
+        )
+        return context
+
+    def dispatch(self, request, *args, **kwargs):
+        if settings.CONFIG["auth"]["enable_testing_auth"]:
+            return redirect("/")
+        if User.objects.filter(is_superuser=True).count() == 0:
+            return redirect("/setup")
+
+        secret_path = kwargs.get("secret_path")
+        configured_secret = settings.CONFIG["auth"].get("local_login_secret_path")
+
+        if not configured_secret or secret_path != configured_secret:
+            return redirect("/login")
+
+        return super().dispatch(request, *args, **kwargs)
+
+
 class LogoutView(View):
     template_name = "forms/logout.html"
 
     def get(self, request):
         if settings.CONFIG["auth"]["enable_testing_auth"]:
             return redirect("/")
-        return render(request, "forms/logout.html", {
-            "base_url": settings.BASE_URL or ""
-        })
+        return render(
+            request, "forms/logout.html", {"base_url": settings.BASE_URL or ""}
+        )
 
     def post(self, request):
         logout(request)
@@ -69,10 +106,11 @@ class SuperuserView(View):
 
     def get(self, request):
         form = SuperuserForm
-        return render(request, "forms/superuser.html", {
-            "form": form,
-            "base_url": settings.BASE_URL or ""
-        })
+        return render(
+            request,
+            "forms/superuser.html",
+            {"form": form, "base_url": settings.BASE_URL or ""},
+        )
 
     def post(self, request):
         form = SuperuserForm(request.POST)
@@ -89,10 +127,11 @@ class SuperuserView(View):
                 form.add_error(f"Unhandled exception: {err}")
             else:
                 return redirect("/login")
-        return render(request, "forms/superuser.html", {
-            "form": form,
-            "base_url": settings.BASE_URL or ""
-        })
+        return render(
+            request,
+            "forms/superuser.html",
+            {"form": form, "base_url": settings.BASE_URL or ""},
+        )
 
 
 class WhoAmIView(APIView):
@@ -113,11 +152,18 @@ class WhoAmIView(APIView):
             "type": "local",
             "avatar_url": "",
         }
-        if social_account and social_account.provider == "github":
+        if social_account:
             user_data = social_account.get_provider_account().get_user_data()
             data["type"] = social_account.provider
-            data["username"] = user_data["login"]
-            data["avatar_url"] = user_data["avatar_url"]
+
+            if social_account.provider == "github":
+                data["username"] = user_data["login"]
+                data["avatar_url"] = user_data["avatar_url"]
+            elif social_account.provider == "okta":
+                data["username"] = user_data.get(
+                    "preferred_username", user_data.get("email", request.user.username)
+                )
+                data["avatar_url"] = user_data.get("picture", "")
         serializer = WhoAmISerializer(data=data)
         if not serializer.is_valid():
             response.mark_failed(str(serializer.errors))

--- a/backend/telescope/views/connection/views.py
+++ b/backend/telescope/views/connection/views.py
@@ -8,7 +8,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from telescope.services.connection import ConnectionService
-from telescope.services.exceptions import SerializerValidationError, ConnectionInUseError
+from telescope.services.exceptions import (
+    SerializerValidationError,
+    ConnectionInUseError,
+)
 from telescope.rbac.manager import RBACManager
 from telescope.rbac import permissions
 

--- a/backend/telescope/views/index.py
+++ b/backend/telescope/views/index.py
@@ -12,9 +12,8 @@ from telescope.response import UIResponse
 @login_required
 def index(request):
     from django.conf import settings
-    return render(request, "index.html", {
-        "base_url": settings.BASE_URL or ""
-    })
+
+    return render(request, "index.html", {"base_url": settings.BASE_URL or ""})
 
 
 class ConfigView(APIView):

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -52,7 +52,17 @@ config:
         key: ""
         organizations: []
         default_group: null
+      okta:
+        enabled: false
+        client_id: ""
+        secret: ""
+        base_url: ""
+        default_group: null
+        scope: "openid profile email"
+        pkce_enabled: true
     force_github_auth: false
+    force_auth_provider: null
+    local_login_secret_path: null
     enable_testing_auth: false
     testing_auth_username: "telescope"
   frontend:
@@ -117,7 +127,8 @@ djangoCollectstatic: 1
 
 # Required secrets in the secret:
 # - DJANGO_SECRET_KEY: Always required for Django security
-# - GITHUB_SECRET: Required only when config.auth.providers.github.enabled=true  
+# - GITHUB_SECRET: Required only when config.auth.providers.github.enabled=true
+# - OKTA_SECRET: Required only when config.auth.providers.okta.enabled=true
 # - DATABASE_PASSWORD: Required only when database.type="postgresql"
 #
 # To use a custom secret name:
@@ -127,6 +138,7 @@ djangoCollectstatic: 1
 #   kubectl create secret generic telescope-secrets \
 #     --from-literal=DJANGO_SECRET_KEY="your-django-secret" \
 #     --from-literal=GITHUB_SECRET="your-github-oauth-secret" \
+#     --from-literal=OKTA_SECRET="your-okta-oauth-secret" \
 #     --from-literal=DATABASE_PASSWORD="your-db-password"
 
 # PodDisruptionBudget for high availability

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4293,9 +4293,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001715",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
-            "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
+            "version": "1.0.30001754",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
+            "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/ui/src/components/common/Sidebar.vue
+++ b/ui/src/components/common/Sidebar.vue
@@ -254,7 +254,9 @@
                         style="color: rgb(209 213 219); background-color: var(--p-primary-700)"
                     />
                     <div class="ml-3 flex-1">
-                        <div class="font-medium text-sm">{{ user.username }}</div>
+                        <div class="font-medium text-sm" v-tooltip.right="usernameTooltip">
+                            {{ displayUsername }}
+                        </div>
                         <div class="text-xs text-gray-400 flex items-center">
                             <i v-if="user.type == 'github'" class="pi pi-github mr-1"></i>
                             {{ user.type }}
@@ -270,7 +272,13 @@
                 >
                     <Avatar icon="pi pi-user" style="color: rgb(209 213 219); background-color: var(--p-primary-700)" />
                     <div class="ml-3 flex-1">
-                        <div class="font-medium text-sm">{{ user.username }}</div>
+                        <div class="font-medium text-sm" v-tooltip.right="usernameTooltip">
+                            {{ displayUsername }}
+                        </div>
+                        <div class="text-xs text-gray-400 flex items-center">
+                            <i v-if="user.type == 'github'" class="pi pi-github mr-1"></i>
+                            {{ user.type }}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -351,6 +359,19 @@ configStore.load()
 const { user } = storeToRefs(useAuthStore())
 
 const isDark = useDark()
+
+// Truncate username if longer than 20 characters
+const displayUsername = computed(() => {
+    if (!user.value?.username) return ''
+    return user.value.username.length > 20
+        ? user.value.username.substring(0, 20) + '...'
+        : user.value.username
+})
+
+// Show tooltip only if username is truncated
+const usernameTooltip = computed(() => {
+    return user.value?.username?.length > 20 ? user.value.username : null
+})
 const toggleDark = useToggle(isDark)
 
 const themeIcon = computed(() => {

--- a/ui/src/components/user/UserProfile.vue
+++ b/ui/src/components/user/UserProfile.vue
@@ -9,12 +9,21 @@
             <DataView :loadings="[loading]" :errors="[error]">
                 <div class="flex flex-col max-w-[800px]">
                     <Header>
-                        <template #title>{{ user.usernam1e }} </template>
+                        <template #title>{{ user.username }} </template>
+                        <template #actions>
+                            <Button
+                                severity="primary"
+                                label="Logout"
+                                icon="pi pi-sign-out"
+                                @click="handleLogout"
+                                size="small"
+                            />
+                        </template>
                     </Header>
                     <div class="mt-4">
                         <ContentBlock header="Profile">
-                            <DataRow name="Username" :value="user.username" />
-                            <DataRow name="Login type" :value="user.type" />
+                            <DataRow name="Username" :value="user.username" :copy="false" />
+                            <DataRow name="Login type" :value="user.type" :copy="false" />
                             <DataRow name="First name">{{ user.firstName || '–' }}</DataRow>
                             <DataRow name="Last name">{{ user.lastName || '–' }}</DataRow>
                             <DataRow name="Permissions" class="pr-2">
@@ -193,5 +202,9 @@ const handleDeleteTokens = async () => {
     if (response.result) {
         userLoad()
     }
+}
+
+const handleLogout = () => {
+    window.location.href = '/logout'
 }
 </script>


### PR DESCRIPTION
# Why

Organizations require SSO integration with their [Okta identity provider](https://www.okta.com/) to manage user authentication centrally.
When SSO is enforced, administrators need a fallback mechanism to access the system during SSO outages or misconfigurations.

# What

**Backend**
- Added Okta OAuth 2.0 authentication with PKCE support
- Added force_auth_provider config to force login through GitHub or Okta (replacement for force_github_auth)
- Added local_login_secret_path for emergency local login via secret URL (e.g., /login/emergency-abc123)
- Fixed SECURE_PROXY_SSL_HEADER configuration for HTTPS detection behind proxies

**UI**
- Truncate long usernames (>20 chars) in sidebar with tooltip
- Show auth provider type (local/github/okta) under username in sidebar
- Added logout button to user profile
