### PR TITLE
chore: get rid of force_github_auth config setting

### DIFF
--- a/backend/telescope/config.py
+++ b/backend/telescope/config.py
@@ -115,17 +115,6 @@ def validate(config, schema):
         errors.append((path, error.message))
 
     if not errors:
-        if (
-            config["auth"]["force_github_auth"]
-            and not config["auth"]["providers"]["github"]["enabled"]
-        ):
-            errors.append(
-                (
-                    "auth.force_github_auth",
-                    "cannot be true if github provider is not enabled",
-                )
-            )
-
         if config["auth"]["force_auth_provider"]:
             provider = config["auth"]["force_auth_provider"]
             if provider not in ["github", "okta"]:
@@ -204,7 +193,6 @@ def get_default_config():
                     "pkce_enabled": True,
                 },
             },
-            "force_github_auth": False,
             "force_auth_provider": None,
             "local_login_secret_path": None,
             "enable_testing_auth": False,

--- a/backend/telescope/templates/forms/login.html
+++ b/backend/telescope/templates/forms/login.html
@@ -45,11 +45,6 @@
     </div>
   </div>
 </div>
-{% if force_github_auth %}
-<script>
-document.getElementById("github_submit").click()
-</script>
-{% endif %}
 {% if force_auth_provider == 'github' %}
 <script>
 document.getElementById("github_submit").click()

--- a/backend/telescope/views/auth/views.py
+++ b/backend/telescope/views/auth/views.py
@@ -34,7 +34,6 @@ class LoginView(views.LoginView):
         "base_url": settings.BASE_URL or "",
         "github_enabled": settings.CONFIG["auth"]["providers"]["github"]["enabled"],
         "okta_enabled": settings.CONFIG["auth"]["providers"]["okta"]["enabled"],
-        "force_github_auth": settings.CONFIG["auth"]["force_github_auth"],
         "force_auth_provider": settings.CONFIG["auth"]["force_auth_provider"],
     }
 
@@ -60,7 +59,6 @@ class LocalLoginView(views.LoginView):
                     "enabled"
                 ],
                 "okta_enabled": settings.CONFIG["auth"]["providers"]["okta"]["enabled"],
-                "force_github_auth": False,
                 "force_auth_provider": None,
             }
         )

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -60,7 +60,6 @@ config:
         default_group: null
         scope: "openid profile email"
         pkce_enabled: true
-    force_github_auth: false
     force_auth_provider: null
     local_login_secret_path: null
     enable_testing_auth: false


### PR DESCRIPTION
# Why

Users should use `force_auth_provider` instead

# What

<!--
Please explain what you did. For small/trivial changes a single paragraph is
probably sufficient. For any larger changes this should include more context.
-->

# References

<!-- Please include links to other artifacts related to this code change if there are any. -->
