### PR TITLE
fix links to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _A handy tool that manages to make close what once was far_
 
 :speech_balloon: **[Telegram](https://t.me/+CGnCz48GF8xmY2Yy)**
 
-:whale:	**[Run locally using Docker](https://iamtelescope.github.io/telescope/docs/setup/quickstart.html)**
+:whale:	**[Run locally using Docker](https://docs.iamtelescope.net/#quickstart)**
 
 ## 🚀 Live installation
 An live instance is available at [https://demo.iamtelescope.net](https://demo.iamtelescope.net).

--- a/backend/telescope/config.py
+++ b/backend/telescope/config.py
@@ -206,7 +206,7 @@ def get_default_config():
         },
         "frontend": {
             "github_url": "https://github.com/iamtelescope/telescope",
-            "docs_url": "https://iamtelescope.github.io/telescope/docs",
+            "docs_url": "https://docs.iamtelescope.net",
             "show_docs_url": True,
             "base_url": "",
         },


### PR DESCRIPTION
# Why

A couple links still point to the https://iamtelescope.github.io/telescope/docs

# What

now they point to https://docs.iamtelescope.net/

# References

<!-- Please include links to other artifacts related to this code change if there are any. -->
