### PR TITLE
bugfix: correctly quote autocompleted fields with dots

### DIFF
--- a/ui/src/components/explorer/controls/QueryEditor.vue
+++ b/ui/src/components/explorer/controls/QueryEditor.vue
@@ -138,7 +138,7 @@ const getKeySuggestions = (range) => {
                 kind: monaco.languages.CompletionItemKind.Keyword,
                 range: range,
                 documentation: documentation,
-                insertText: name,
+                insertText: name.includes('.') ? '"' + name + '"' : name,
                 command: {
                     id: 'editor.action.triggerSuggest',
                 },
@@ -180,7 +180,9 @@ const getValueSuggestions = async (key, value, range, quoteChar) => {
         incomplete: false,
     }
     let items = []
-    if (sourceColumnsNames.includes(key)) {
+    const unquotedKey = key.replace(/^"|"$/g, '')
+    if (sourceColumnsNames.includes(unquotedKey)) {
+        key = unquotedKey
         if (props.source.columns[key].autocomplete) {
             if (props.source.columns[key].values.length > 0) {
                 items = prepareSuggestionValues(props.source.columns[key].values, quoteChar)
@@ -219,8 +221,9 @@ const getSuggestions = async (word, position, textBeforeCursor) => {
     parser.parse(textBeforeCursor, false, true)
 
     if (parser.state == State.KEY || parser.state == State.INITIAL || parser.state == State.BOOL_OP_DELIMITER) {
-        if (sourceColumnsNames.includes(word.word)) {
-            suggestions = getOperatorsSuggestions(word.word, position)
+        const unquotedWord = word.word.replace(/^"|"$/g, '')
+        if (sourceColumnsNames.includes(unquotedWord)) {
+            suggestions = getOperatorsSuggestions(unquotedWord, position)
         } else {
             suggestions = getKeySuggestions(range)
         }

--- a/ui/src/utils/monaco.js
+++ b/ui/src/utils/monaco.js
@@ -102,7 +102,7 @@ function initMonacoSetup() {
 
     monaco.languages.register({ id: 'flyql' })
     monaco.languages.setLanguageConfiguration('flyql', {
-        wordPattern: /([^\`\~\!\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g,
+        wordPattern: /([^\`\~\!\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\,\<\>\/\s]+)/g,
     })
     monaco.languages.registerDocumentSemanticTokensProvider('flyql', getFlyqlTokenProvider())
 }


### PR DESCRIPTION
# Why
Columns autocompleted in the query box aren't quoted correctly when they contain periods. These are necessary since dots without quotes indicate a nested field reference in Starrocks / Clickhouse sources, while autocompleted fields are always top level.
<img width="848" height="388" alt="image" src="https://github.com/user-attachments/assets/1ea5eb77-e2f8-4c70-87a7-c36add675193" />

<img width="567" height="287" alt="image" src="https://github.com/user-attachments/assets/fe357dab-61c3-4546-8061-6e7e389249c0" />


<!--
Please describe why you are proposing this code change.
-->

# What
Add quotes around autocompleted columns with `.` while still using unquoted columns for generating suggestions 
<!--
Please explain what you did. For small/trivial changes a single paragraph is
probably sufficient. For any larger changes this should include more context.
-->

# References
Reproduction steps
1. Create Starocks/Clickhouse source with a top level field containing a period and autocomplete enabled e.g "test.column"
2. In the logs explorer, autocomplete the column and try run the query

<!-- Please include links to other artifacts related to this code change if there are any. -->
